### PR TITLE
WebService fix

### DIFF
--- a/Scansite4/WebService/src/main/java/edu/mit/scansite/webservice/proteinscan/ProteinIdentifierScanService.java
+++ b/Scansite4/WebService/src/main/java/edu/mit/scansite/webservice/proteinscan/ProteinIdentifierScanService.java
@@ -19,7 +19,7 @@ import static edu.mit.scansite.webservice.proteinscan.ProteinScanUtils.*;
 
 //@Path("/proteinscan/identifier={identifier: \\S+}{dsshortname: (/dsshortname=[A-Za-z]+)?}{motifclass: (/motifclass=[A-Za-z]+)?}{motifshortnames: (/motifshortnames=[\\S~]*)?}{stringency: (/stringency=[A-Za-z]+)?}{referenceproteome: (/referenceproteome=[A-Za-z]+)?}")
 //@Path("/proteinscan/identifier={identifier: \\S+}/dsshortname={dsshortname: [A-Za-z]+}/motifclass={motifclass: [A-Za-z]+}{motifshortnames: (/motifshortnames=[\\S~]*)?}{stringency:(/stringency=[A-Za-z]+)?}{referenceproteome:(/referenceproteome=[A-Za-z]+)?}")
-@Path("/proteinscan/identifier={identifier: [a-zA-Z0-9_.-]+}{dsshortname: (/dsshortname=[A-Za-z]+)?}{motifclass: (/motifclass=[A-Za-z]+)?}{motifshortnames: (/motifshortnames=[a-zA-Z0-9_.,-]*)?}{stringency: (/stringency=[A-Za-z]+)?}{referenceproteome: (/referenceproteome=[A-Za-z]+)?}")
+@Path("/proteinscan/identifier={identifier: [a-zA-Z0-9_.-]+}{dsshortname: (/dsshortname=[A-Za-z]+)?}{motifclass: (/motifclass=[A-Za-z]+)?}{motifshortnames: (/motifshortnames=[a-zA-Z0-9_.,-~]*)?}{stringency: (/stringency=[A-Za-z]+)?}{referenceproteome: (/referenceproteome=[A-Za-z]+)?}")
 public class ProteinIdentifierScanService extends ProteinScanWebService {
 	/**
 	 * @param proteinIdentifier


### PR DESCRIPTION
Added the motif short name separator as allowed symbol to the regex. This way given examples using the separator will no longer result in an error